### PR TITLE
ZNC version 1.6.2, docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 MAINTAINER Nathan Handler <nathan.handler@gmail.com>
 
-ENV ZNC_VERSION 1.6.1
+ENV ZNC_VERSION 1.6.2
 
 RUN apt-get update && DEBIAN_FRONTEND=non_interactive apt-get install -y \
     build-essential \

--- a/README.md
+++ b/README.md
@@ -1,93 +1,63 @@
 # ZNC for Docker
-
 Run the [ZNC][] IRC Bouncer in a Docker container.
 
-[ZNC]: http://znc.in
-
 ## Prerequisites
-
 1. Install [Docker][].
 2. Make .znc folder: `mkdir $HOME/.znc`
 
-[Docker]: http://docker.io/
-
 ## Running
+To retain your ZNC settings between runs, you'll most likely want to bind a directory from the host to `/znc-data` in the container. For example:
 
-To retain your ZNC settings between runs, you'll most likely want to
-bind a directory from the host to `/znc-data` in the container. For
-example:
+```
+docker run -d -p 6667 -v $HOME/.znc:/znc-data jimeh/znc
+```
 
-    docker run -d -p 6667 -v $HOME/.znc:/znc-data jimeh/znc
+This will download the image if needed, and create a default config file in your data directory unless you already have a config in place. The default config has ZNC listening on port 6667. To see which port on the host has been exposed:
 
-This will download the image if needed, and create a default config file in
-your data directory unless you already have a config in place. The default
-config has ZNC listening on port 6667. To see which port on the host has been
-exposed:
-
-    docker ps
+```
+docker ps
+```
 
 Or if you want to specify which port to map the default 6667 port to:
 
-    docker run -d -p 36667:6667 -v $HOME/.znc:/znc-data jimeh/znc
+```
+docker run -d -p 36667:6667 -v $HOME/.znc:/znc-data jimeh/znc
+```
 
 Resulting in port 36667 on the host mapping to 6667 within the container.
 
-
 ## Configuring
+If you've let the container create a default config for you, the default username/password combination is admin/admin. You can access the web-interface to create your own user by pointing your web-browser at the opened port.
 
-If you've let the container create a default config for you, the default
-username/password combination is admin/admin. You can access the web-interface
-to create your own user by pointing your web-browser at the opened port.
-
-I'd recommend you create your own user by cloning the admin user, then ensure
-your new cloned user is set to be an admin user. Once you login with your new
-user go ahead and delete the default admin user.
-
+I'd recommend you create your own user by cloning the admin user, then ensure your new cloned user is set to be an admin user. Once you login with your new user go ahead and delete the default admin user.
 
 ## External Modules
+If you need to use external modules, simply place the original `*.cpp` source files for the modules in your `{DATADIR}/modules` directory. The startup script will automatically build all .cpp files in that directory with `znc-buildmod` every time you start the container.
 
-If you need to use external modules, simply place the original `*.cpp` source
-files for the modules in your `{DATADIR}/modules` directory. The startup
-script will automatically build all .cpp files in that directory with
-`znc-buildmod` every time you start the container.
-
-This ensures that you can easily add new external modules to your znc
-configuration without having to worry about building them. And it only slows
-down ZNC's startup with a few seconds.
-
+This ensures that you can easily add new external modules to your znc configuration without having to worry about building them. And it only slows down ZNC's startup with a few seconds.
 
 ## Notes on DATADIR
+ZNC needs a data/config directory to run. Within the container it uses `/znc-data`, so to retain this data when shutting down a container, you should mount a directory from the host. Hence `-v $HOME/.znc:/znc-data` is part of the instructions above.
 
-ZNC needs a data/config directory to run. Within the container it uses
-`/znc-data`, so to retain this data when shutting down a container, you should
-mount a directory from the host. Hence `-v $HOME/.znc:/znc-data` is part of
-the instructions above.
-
-As ZNC needs to run as it's own user within the container, the directory will
-have it's ownership changed to UID 1000 (user) and GID 1000 (group). Meaning
-after the first run, you might need root access to manually modify the data
-directory.
-
+As ZNC needs to run as it's own user within the container, the directory will have it's ownership changed to UID 1000 (user) and GID 1000 (group). Meaning after the first run, you might need root access to manually modify the data directory.
 
 ## Passing Custom Arguments to ZNC
-
-As `docker run` passes all arguments after the image name to the entrypoint
-script, the [start-znc][] script simply passes all arguments along to ZNC.
-
-[start-znc]: https://github.com/jimeh/docker-znc/blob/master/start-znc
+As `docker run` passes all arguments after the image name to the entrypoint script, the [start-znc][] script simply passes all arguments along to ZNC.
 
 For example, if you want to use the `--makepass` option, you would run:
 
-    docker run -i -t -v $HOME/.znc:/znc-data jimeh/znc --makepass
+```
+docker run -i -t -v $HOME/.znc:/znc-data jimeh/znc --makepass
+```
 
-Make note of the use of `-i` and `-t` instead of `-d`. This attaches us to the
-container, so we can interact with ZNC's makepass process. With `-d` it would
-simply run in the background.
-
+Make note of the use of `-i` and `-t` instead of `-d`. This attaches us to the container, so we can interact with ZNC's makepass process. With `-d` it would simply run in the background.
 
 ## Building It Yourself
-
 1. Follow Prerequisites above.
 2. Checkout source: `git clone https://github.com/jimeh/docker-znc.git && cd docker-znc`
 3. Build container: `sudo docker build -t $(whoami)/znc .`
 4. Run container: `sudo docker run -d -p 6667 -v $HOME/.znc:/znc-data $(whoami)/znc`
+
+[znc]: http://znc.in
+[docker]: http://docker.io/
+[start-znc]: https://github.com/jimeh/docker-znc/blob/master/start-znc

--- a/README.md
+++ b/README.md
@@ -3,28 +3,22 @@ Run the [ZNC][] IRC Bouncer in a Docker container.
 
 ## Prerequisites
 1. Install [Docker][].
-2. Make .znc folder: `mkdir $HOME/.znc`
+
+## Building
+
+```
+make
+```
 
 ## Running
-To retain your ZNC settings between runs, you'll most likely want to bind a directory from the host to `/znc-data` in the container. For example:
 
 ```
-docker run -d -p 6667 -v $HOME/.znc:/znc-data jimeh/znc
+make run
 ```
 
-This will download the image if needed, and create a default config file in your data directory unless you already have a config in place. The default config has ZNC listening on port 6667. To see which port on the host has been exposed:
+Configs are stored in the docker container at `/znc-data` and on the host in `${HOME}/.znc`
 
-```
-docker ps
-```
-
-Or if you want to specify which port to map the default 6667 port to:
-
-```
-docker run -d -p 36667:6667 -v $HOME/.znc:/znc-data jimeh/znc
-```
-
-Resulting in port 36667 on the host mapping to 6667 within the container.
+The defult port is `36667`
 
 ## Configuring
 If you've let the container create a default config for you, the default username/password combination is admin/admin. You can access the web-interface to create your own user by pointing your web-browser at the opened port.
@@ -32,12 +26,12 @@ If you've let the container create a default config for you, the default usernam
 I'd recommend you create your own user by cloning the admin user, then ensure your new cloned user is set to be an admin user. Once you login with your new user go ahead and delete the default admin user.
 
 ## External Modules
-If you need to use external modules, simply place the original `*.cpp` source files for the modules in your `{DATADIR}/modules` directory. The startup script will automatically build all .cpp files in that directory with `znc-buildmod` every time you start the container.
+If you need to use external modules, simply place the original `*.cpp` source files for the modules in your `${HOME}/.znc/modules` directory. The startup script will automatically build all .cpp files in that directory with `znc-buildmod` every time you start the container.
 
 This ensures that you can easily add new external modules to your znc configuration without having to worry about building them. And it only slows down ZNC's startup with a few seconds.
 
 ## Notes on DATADIR
-ZNC needs a data/config directory to run. Within the container it uses `/znc-data`, so to retain this data when shutting down a container, you should mount a directory from the host. Hence `-v $HOME/.znc:/znc-data` is part of the instructions above.
+ZNC needs a data/config directory to run. Within the container it uses `/znc-data`, so to retain this data when shutting down a container, you should mount a directory from the host. Hence `-v ${HOME}/.znc:/znc-data` is part of the instructions above.
 
 As ZNC needs to run as it's own user within the container, the directory will have it's ownership changed to UID 1000 (user) and GID 1000 (group). Meaning after the first run, you might need root access to manually modify the data directory.
 
@@ -47,16 +41,10 @@ As `docker run` passes all arguments after the image name to the entrypoint scri
 For example, if you want to use the `--makepass` option, you would run:
 
 ```
-docker run -i -t -v $HOME/.znc:/znc-data jimeh/znc --makepass
+docker run -i -t -v ${HOME}/.znc:/znc-data ${USER}/znc --makepass
 ```
 
 Make note of the use of `-i` and `-t` instead of `-d`. This attaches us to the container, so we can interact with ZNC's makepass process. With `-d` it would simply run in the background.
-
-## Building It Yourself
-1. Follow Prerequisites above.
-2. Checkout source: `git clone https://github.com/jimeh/docker-znc.git && cd docker-znc`
-3. Build container: `sudo docker build -t $(whoami)/znc .`
-4. Run container: `sudo docker run -d -p 6667 -v $HOME/.znc:/znc-data $(whoami)/znc`
 
 [znc]: http://znc.in
 [docker]: http://docker.io/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ If you've let the container create a default config for you, the default usernam
 
 I'd recommend you create your own user by cloning the admin user, then ensure your new cloned user is set to be an admin user. Once you login with your new user go ahead and delete the default admin user.
 
+## SSL access
+To enable SSL access to both HTTP and IRC, execute the following commands from within the DATADIR:
+
+```
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
+cat cert.pem > znc.pem
+cat key.pem >> znc.pem
+```
+
+Afterwards, shut down your container and start it up again.
+
 ## External Modules
 If you need to use external modules, simply place the original `*.cpp` source files for the modules in your `${HOME}/.znc/modules` directory. The startup script will automatically build all .cpp files in that directory with `znc-buildmod` every time you start the container.
 
@@ -33,7 +44,7 @@ This ensures that you can easily add new external modules to your znc configurat
 ## Notes on DATADIR
 ZNC needs a data/config directory to run. Within the container it uses `/znc-data`, so to retain this data when shutting down a container, you should mount a directory from the host. Hence `-v ${HOME}/.znc:/znc-data` is part of the instructions above.
 
-As ZNC needs to run as it's own user within the container, the directory will have it's ownership changed to UID 1000 (user) and GID 1000 (group). Meaning after the first run, you might need root access to manually modify the data directory.
+As ZNC needs to run as it's own user within the container, the directory will have it's ownership changed to UID 1000 (user) and GID 1000 (group). Meaning after the first run, you might need root access to modify the data directory from outside the container.
 
 ## Passing Custom Arguments to ZNC
 As `docker run` passes all arguments after the image name to the entrypoint script, the [start-znc][] script simply passes all arguments along to ZNC.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,15 +52,6 @@ if [ ! -f "${DATADIR}/configs/znc.conf" ]; then
   cp /znc.conf.default "${DATADIR}/configs/znc.conf"
 fi
 
-# Create the self-signed SSL cert if it doesn't exist
-if [ ! -f "${DATADIR}/znc.pem" ]; then
-  echo "Please create ${DATADIR}/znc.pem"
-  echo "cd ~/.znc"
-  echo "openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes"
-  echo "cp key.pem znc.pem"
-  echo "cat cert.pem >> znc.pem"
-fi
-
 # Make sure $DATADIR is owned by znc user. This effects ownership of the
 # mounted directory on the host machine too.
 chown -R znc:znc "$DATADIR"

--- a/znc.conf.default
+++ b/znc.conf.default
@@ -8,7 +8,7 @@
 // But if you feel risky, you might want to read help on /znc saveconfig and /znc rehash.
 // Also check http://en.znc.in/wiki/Configuration
 
-Version = 1.6.1
+Version = 1.6.2
 <Listener l>
         Port = 6667
         IPv4 = true


### PR DESCRIPTION
- Updated ZNC version to 1.6.2
- Cleaned up README with relevant build info, etc.
