### PR TITLE
Bump to 1.6.5, switch to github for src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM debian:jessie
 MAINTAINER Nathan Handler <nathan.handler@gmail.com>
 
-ENV ZNC_VERSION 1.6.3
+ENV ZNC_VERSION 1.6.5
 ONBUILD ENV DEBIAN_FRONTEND=non_interactive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    automake \
     build-essential \
+    git \
     libcurl4-openssl-dev \
     libicu-dev \
     libjson-perl \
@@ -22,9 +24,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tcl-dev \
     wget
 RUN mkdir -p /src
-RUN wget --quiet --directory-prefix=/src "http://znc.in/releases/archive/znc-${ZNC_VERSION}.tar.gz"
-RUN tar xvzf "/src/znc-${ZNC_VERSION}.tar.gz" --directory /src
-RUN cd "/src/znc-${ZNC_VERSION}" \
+RUN cd /src && git clone https://github.com/znc/znc.git
+RUN cd "/src/znc" \
+    && git checkout "tags/znc-${ZNC_VERSION}" \
+    && git submodule update --init --recursive \
+    && ./autogen.sh \
     && ./configure --enable-perl --enable-python --enable-tcl --enable-cyrus \
     && (make || make) \
     && make install

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ start:
 	docker start $(NAME)
 
 stop:
-	docker stop $(NAME)
+	docker stop $(NAME) || true
 
 rm: stop
-	docker rm $(NAME)
+	docker rm $(NAME) || true
 
 clean: stop rm
 	docker rmi $(NAME)

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,17 @@ run:
 .PHONY: debug
 debug:
 	docker run -it -p 29492:6667 --name $(NAME)-debug -v ${HOME}/.znc:/znc-data ${USER}/znc
+
+start:
+	docker start $(NAME)
+
+stop:
+	docker stop $(NAME)
+
+rm: stop
+	docker rm $(NAME)
+
+clean: stop rm
+	docker rmi $(NAME)
+
+bounce: build stop rm run

--- a/znc.conf.default
+++ b/znc.conf.default
@@ -8,7 +8,7 @@
 // But if you feel risky, you might want to read help on /znc saveconfig and /znc rehash.
 // Also check http://en.znc.in/wiki/Configuration
 
-Version = 1.6.4
+Version = 1.6.5
 <Listener l>
         Port = 6667
         IPv4 = true


### PR DESCRIPTION
- Bump version to 1.6.5
- Switch to github and git clone for source (znc.in is currently down)
- Add some helpful make targets